### PR TITLE
(fix) Check to prevent deprecation notice on PHP 8.1

### DIFF
--- a/drop-ins/object-cache.php
+++ b/drop-ins/object-cache.php
@@ -2102,7 +2102,7 @@ LUA;
             $group = 'default';
         }
 
-        $salt = defined( 'WP_REDIS_PREFIX' ) ? trim( WP_REDIS_PREFIX ) : '';
+        $salt = defined( 'WP_REDIS_PREFIX' ) && WP_REDIS_PREFIX ? trim( WP_REDIS_PREFIX ) : '';
         $prefix = $this->is_global_group( $group ) ? $this->global_prefix : $this->blog_prefix;
 
         $key = $this->sanitize_key_part( $key );


### PR DESCRIPTION
Hej,

this PR removes adds a check against `WP_REDIS_PREFIX` being `null` and thereby removes the deprecation notice under PHP 8.1:

```sh
PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /path/web/app/object-cache.php on line 2105
Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /path/web/app/object-cache.php on line 2105
```