### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -323,7 +323,7 @@ class Cache {
 	 * @return bool
 	 */
 	private function delete( $path, $recursive = false ) {
-		if ( file_exists( $path ) && is_writable( $path ) ) {
+		if ( null !== $path && file_exists( $path ) && is_writable( $path ) ) {
 			require_once( ABSPATH . '/wp-admin/includes/file.php' );
 
 			$context = $path;


### PR DESCRIPTION
I found that during a plugin update from update-core.php and using PHP 8.1 I would get the following error.

`Deprecated: file_exists(): Passing null to parameter 1 ($filename) of type string is deprecated in /sites/thefragens.net/files/wp-content/plugins/spinupwp/src/Cache.php on line 326`