### PR TITLE
Increase timeout limits

### DIFF
--- a/drop-ins/object-cache.php
+++ b/drop-ins/object-cache.php
@@ -599,8 +599,8 @@ class WP_Object_Cache {
             'host' => '127.0.0.1',
             'port' => 6379,
             'database' => 0,
-            'timeout' => 1,
-            'read_timeout' => 1,
+            'timeout' => 5,
+            'read_timeout' => 5,
             'retry_interval' => null,
             'persistent' => false,
         ];


### PR DESCRIPTION
<!-- Indicate the issue resolved by this pull request. -->

Resolves #65 

## Description

<!-- Describe how and why changes were made. -->
The timeout and read_timeout values being set in drop-ins/object-cache.php on lines [602](https://github.com/spinupwp/spinupwp-plugin/blob/develop/drop-ins/object-cache.php#L602) and [603](https://github.com/spinupwp/spinupwp-plugin/blob/develop/drop-ins/object-cache.php#L603) are both very short at 1 second.

This can easily cause timeouts and errors as sites grow and purging their cache takes longer.

These values have been increased to 5 seconds.

## Visuals

<!-- Include screenshots or video to better communicate the changes. -->
Successful object cache Purging:
<img width="500" alt="Screen Shot 2023-12-04 at 4 41 07 PM" src="https://github.com/spinupwp/spinupwp-plugin/assets/557884/9b54e8ad-0ce4-4c76-ad60-96e2d75f8fc1">


## Testing Instructions

<!-- Help others test the pull request as efficiently as possible. -->

1. Install plugin with updated timeouts
2. Go to homepage > Hover over Cache > Click Purge Object Cache

Note: I attempted to verify that the increased timeouts prevent errors by adding thousands of WooCommerce products and fake posts on a development server, although there weren't any errors during purging the object cache, I haven't been able to verify the increased timeouts prevents errors.

## Pre-review Checklist

<!-- Complete these tasks prior to a review. -->

- [x] Acceptance criteria have been satisfied and marked in the related issue.
- [x] Self-review of code changes has been completed.
- [x] PHP, JS and CSS code has been auto formatted.
- [x] Self-review of UX changes has been completed.
- [ ] Related issue has been marked ready for review in the project.
- [ ] Related issue has been marked ready for design review in the project (where necessary).
- [ ] Related issue has been marked ready for code review in the project.
- [x] Review has been requested from team member(s).