### PR TITLE
Add option to purge current url only

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -51,7 +51,7 @@ class Cache {
 			$this->cli->register_command( 'spinupwp cache', CacheCommands::class );
 		}
 
-		if ( $this->is_page_cache_enabled() ) {
+		if ( $this->is_page_cache_enabled() && ! is_admin() ) {
 			$this->admin_bar->add_item( __( 'Purge this URL', 'spinupwp' ), 'purge-url' );
 		}
 

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -51,8 +51,13 @@ class Cache {
 			$this->cli->register_command( 'spinupwp cache', CacheCommands::class );
 		}
 
+		if ( $this->is_page_cache_enabled() ) {
+			$this->admin_bar->add_item( __( 'Purge this URL', 'spinupwp' ), 'purge-url' );
+		}
+
 		add_action( 'spinupwp_purge_object_cache', array( $this, 'purge_object_cache' ) );
 		add_action( 'spinupwp_purge_page_cache', array( $this, 'purge_page_cache' ) );
+		add_action( 'spinupwp_purge_url', array( $this, 'purge_url' ) );
 		add_action( 'admin_init', array( $this, 'handle_manual_purge_action' ) );
 		add_action( 'transition_post_status', array( $this, 'purge_post_on_update' ), 10, 3 );
 		add_action( 'delete_post', array( $this, 'purge_post_on_delete' ), 10, 1 );
@@ -73,7 +78,7 @@ class Cache {
 
 		$action = filter_input( INPUT_GET, 'spinupwp_action' );
 
-		if ( ! $action || ! in_array( $action, array( 'purge-all', 'purge-object', 'purge-page' ) ) ) {
+		if ( ! $action || ! in_array( $action, array( 'purge-all', 'purge-object', 'purge-page', 'purge-url' ) ) ) {
 			return;
 		}
 
@@ -94,6 +99,12 @@ class Cache {
 		if ( 'purge-page' === $action ) {
 			$purge = $this->purge_page_cache();
 			$type  = 'page';
+		}
+		
+		if ( 'purge-url' === $action ) {
+			$url = $_SERVER['HTTP_REFERER'];
+			$purge = $this->purge_url($url);
+			$type  = 'url';
 		}
 
 		$redirect_url = isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : admin_url();


### PR DESCRIPTION
<!-- Indicate the issue resolved by this pull request. -->

Resolves #47 

## Description

<!-- Describe how and why changes were made. -->
Currently only the object cache and page caching for an entire site can be purged.  This PR adds the option to purge the current URL only.

## Visuals
<img width="161" alt="Screen Shot 2024-01-09 at 2 43 40 PM" src="https://github.com/spinupwp/spinupwp-plugin/assets/557884/65c61143-790c-4a19-a2c0-08688ef7db99">


## Testing Instructions

<!-- Help others test the pull request as efficiently as possible. -->
1. Login, Install, and activate SpinupWP plugin on a SpinupWP hosted site
2. Go to the site's homepage
3. Open the site's homepage in an incognito tab (don't login in the incognito tab)
4. In the incognito tab right click on the homepage > click Inspect > go to the Network tab > refresh page > view the headers for the url ( should be first item listed in the Network tab ) > Go to Response Headers > Fastcgi-Cache > You should see HIT or MISS > If you see MISS refresh the page again > You should see HIT ( this indicates the page has been cached )
<img width="500" alt="Screen Shot 2024-01-09 at 2 50 25 PM" src="https://github.com/spinupwp/spinupwp-plugin/assets/557884/4320047a-04e5-4193-868d-43b05d578938"><br/>
5. Go back to non-incognito tab (where you're logged in) > go to homepage ( or another URL ) > hover over Cache in admin bar > Click "Purge this URL"
6. Go back to incognito tab > Inspect > Network tab > Headers > Response Headers > Fastcgi-Cache > You should see MISS  ( this means the cache has been cleared ) > Refresh the page again and the Response Headers > Fastcgi-Cache should say HIT
<img width="500" alt="Screen Shot 2024-01-09 at 2 52 06 PM" src="https://github.com/spinupwp/spinupwp-plugin/assets/557884/ed7014c0-dbcf-4e92-9e34-7dc5ebf4bad2"><br/>
7. Repeat steps 5 & 6 to test additional URLs

## Pre-review Checklist

<!-- Complete these tasks prior to a review. -->

- [x] Acceptance criteria have been satisfied and marked in the related issue.
- [x] Self-review of code changes has been completed.
- [x] PHP, JS and CSS code has been auto formatted.
- [x] Self-review of UX changes has been completed.
- [ ] Related issue has been marked ready for review in the project.
- [ ] Related issue has been marked ready for design review in the project (where necessary).
- [ ] Related issue has been marked ready for code review in the project.
- [x] Review has been requested from team member(s).