### PR TITLE
Fix "Purge All Caches" when Redis error bug 

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -82,7 +82,10 @@ class Cache {
 		}
 
 		if ( 'purge-all' === $action ) {
-			$purge = $this->purge_object_cache() && $this->purge_page_cache();
+			$purge_object_cache = $this->purge_object_cache();
+			$purge_page_cache = $this->purge_page_cache();
+			
+			$purge = $purge_object_cache && $purge_page_cache;
 			$type  = 'all';
 		}
 


### PR DESCRIPTION
Resolves #74

## Description

This fixes the "Purge All Caches" commands so that clearing the page cache will still work even if there is an error with clearing the Redis cache. We are no longer using the && operator to call the functions, but the `purge` parameter will still only show as true if both functions are successful. 

## Testing

1. On a SpinupWP managed server, run `sudo service redis stop` to stop redis. This will cause an error when clearing the object cache. 
2. Click on "Purge All Caches". 
3. Observe the page cache. Without this fix, the page cache will not be cleared, with the fix it will be cleared. 