### PR TITLE
Fix "Function _load_textdomain_just_in_time was called incorrectly"

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -38,6 +38,25 @@ class Cache {
 	public function init() {
 		$this->set_cache_path();
 
+		add_action( 'init', array( $this, 'register_admin_bar_menu_items' ) );
+		add_action( 'spinupwp_purge_object_cache', array( $this, 'purge_object_cache' ) );
+		add_action( 'spinupwp_purge_page_cache', array( $this, 'purge_page_cache' ) );
+		add_action( 'spinupwp_purge_url', array( $this, 'purge_url' ) );
+		add_action( 'admin_init', array( $this, 'handle_manual_purge_action' ) );
+		add_action( 'transition_post_status', array( $this, 'purge_post_on_update' ), 10, 3 );
+		add_action( 'delete_post', array( $this, 'purge_post_on_delete' ), 10, 1 );
+		add_action( 'switch_theme', array( $this, 'purge_page_cache' ) );
+		add_action( 'comment_post', array( $this, 'purge_post_on_comment' ), 10, 2 );
+		add_action( 'wp_set_comment_status', array( $this, 'purge_post_by_comment' ) );
+		add_action( 'upgrader_process_complete', array( $this, 'purge_page_cache_on_shutdown' ) );
+	}
+
+	/**
+	 * Register cache purge menu items in the admin bar.
+	 *
+	 * @return void
+	 */
+	public function register_admin_bar_menu_items() {
 		if ( $this->is_object_cache_enabled() && $this->is_page_cache_enabled() ) {
 			$this->admin_bar->add_item( __( 'Purge All Caches', 'spinupwp' ), 'purge-all' );
 		}
@@ -54,17 +73,6 @@ class Cache {
 		if ( $this->is_page_cache_enabled() && ! is_admin() ) {
 			$this->admin_bar->add_item( __( 'Purge this URL', 'spinupwp' ), 'purge-url' );
 		}
-
-		add_action( 'spinupwp_purge_object_cache', array( $this, 'purge_object_cache' ) );
-		add_action( 'spinupwp_purge_page_cache', array( $this, 'purge_page_cache' ) );
-		add_action( 'spinupwp_purge_url', array( $this, 'purge_url' ) );
-		add_action( 'admin_init', array( $this, 'handle_manual_purge_action' ) );
-		add_action( 'transition_post_status', array( $this, 'purge_post_on_update' ), 10, 3 );
-		add_action( 'delete_post', array( $this, 'purge_post_on_delete' ), 10, 1 );
-		add_action( 'switch_theme', array( $this, 'purge_page_cache' ) );
-		add_action( 'comment_post', array( $this, 'purge_post_on_comment' ), 10, 2 );
-		add_action( 'wp_set_comment_status', array( $this, 'purge_post_by_comment' ) );
-		add_action( 'upgrader_process_complete', array( $this, 'purge_page_cache_on_shutdown' ) );
 	}
 
 
@@ -88,8 +96,8 @@ class Cache {
 
 		if ( 'purge-all' === $action ) {
 			$purge_object_cache = $this->purge_object_cache();
-			$purge_page_cache = $this->purge_page_cache();
-			
+			$purge_page_cache   = $this->purge_page_cache();
+
 			$purge = $purge_object_cache && $purge_page_cache;
 			$type  = 'all';
 		}
@@ -103,10 +111,10 @@ class Cache {
 			$purge = $this->purge_page_cache();
 			$type  = 'page';
 		}
-		
+
 		if ( 'purge-url' === $action ) {
-			$url = $_SERVER['HTTP_REFERER'];
-			$purge = $this->purge_url($url);
+			$url   = $_SERVER['HTTP_REFERER'];
+			$purge = $this->purge_url( $url );
 			$type  = 'url';
 		}
 
@@ -302,20 +310,20 @@ class Cache {
 	 */
 	public function purge_url( $url ) {
 		$cache_paths = $this->get_cache_paths_for_url( $url );
-		
+
 		$all_deleted = true;
-		foreach ($cache_paths as $path) {
-			$deleted =  $this->delete( $path );
+		foreach ( $cache_paths as $path ) {
+			$deleted = $this->delete( $path );
 			do_action( 'spinupwp_url_purged', $url, $deleted );
 			$all_deleted &= $deleted;
 		}
-		
+
 		return $all_deleted;
 	}
 
 	/**
 	 * Gets the cache file paths for a given URL.
-	 * 
+	 *
 	 * Must be using the default Nginx cache options (levels=1:2)
 	 * https://www.digitalocean.com/community/tutorials/how-to-setup-fastcgi-caching-with-nginx-on-your-vps#purging-the-cache
 	 *
@@ -325,14 +333,14 @@ class Cache {
 	 */
 	private function get_cache_paths_for_url( $url ) {
 		$cache_keys = $this->get_cache_keys_for_url( $url );
-		
+
 		$cache_paths = array();
-		foreach ($cache_keys as $key) {
-			$hashed_key = md5($key);
-			$path = substr( $hashed_key, - 1 ) . '/' . substr( $hashed_key, - 3, 2 ) . '/' . $hashed_key;
+		foreach ( $cache_keys as $key ) {
+			$hashed_key    = md5( $key );
+			$path          = substr( $hashed_key, - 1 ) . '/' . substr( $hashed_key, - 3, 2 ) . '/' . $hashed_key;
 			$cache_paths[] = trailingslashit( $this->cache_path ) . $path;
 		}
-		
+
 		return $cache_paths;
 	}
 
@@ -350,11 +358,11 @@ class Cache {
 	private function get_cache_keys_for_url( $url ) {
 		// Default cache key
 		$parsed_url = parse_url( trailingslashit( $url ) );
-		$cache_keys = array($parsed_url['scheme'] . 'GET' . $parsed_url['host'] . $parsed_url['path']);
+		$cache_keys = array( $parsed_url['scheme'] . 'GET' . $parsed_url['host'] . $parsed_url['path'] );
 
 		// Allow the cache keys to be modified
-		$cache_keys = apply_filters('spinupwp_cache_keys_for_url', $cache_keys, $url);
-		
+		$cache_keys = apply_filters( 'spinupwp_cache_keys_for_url', $cache_keys, $url );
+
 		return $cache_keys;
 	}
 


### PR DESCRIPTION
Resolves #87, #95

To replicate this locally, you'll need to spoof a Spinup site by adding the following to the top of your `wp-config.php` file:

```
putenv( 'SPINUPWP_SITE=true' );
putenv( 'SPINUPWP_CACHE_PATH=/tmp/cache/wordpress.test' );
```