### PR TITLE
Update SPINUPWP_REDIS_* variables and do not set WP_REDIS_SELECTIVE_FLUSH to true

### DIFF
--- a/drop-ins/object-cache.php
+++ b/drop-ins/object-cache.php
@@ -236,10 +236,6 @@ function wp_cache_init() {
         define( 'WP_REDIS_PREFIX', get_cache_key_salt());
     }
 
-    if ( ! defined( 'WP_REDIS_SELECTIVE_FLUSH' ) ) {
-        define( 'WP_REDIS_SELECTIVE_FLUSH', true );
-    }
-
     if ( ! ( $wp_object_cache instanceof WP_Object_Cache ) ) {
         $fail_gracefully = defined( 'WP_REDIS_GRACEFUL' ) && WP_REDIS_GRACEFUL;
 
@@ -633,7 +629,7 @@ class WP_Object_Cache {
             'scheme' => 'tcp',
             'host' => '127.0.0.1',
             'port' => 6379,
-            'database' => getenv('SPINUPWP_CACHE_DB') ?? 0,
+            'database' => getenv('SPINUPWP_REDIS_DB') ?? 0,
             'timeout' => 5,
             'read_timeout' => 5,
             'retry_interval' => null,
@@ -653,8 +649,8 @@ class WP_Object_Cache {
         ];
 
 
-        if ( getenv( 'SPINUPWP_CACHE_USERNAME' ) && getenv( 'SPINUPWP_CACHE_PASSWORD' ) ) {
-            $parameters['password'] = [getenv( 'SPINUPWP_CACHE_USERNAME' ), getenv( 'SPINUPWP_CACHE_PASSWORD' )];
+        if ( getenv( 'SPINUPWP_REDIS_USERNAME' ) && getenv( 'SPINUPWP_REDIS_PASSWORD' ) ) {
+            $parameters['password'] = [getenv( 'SPINUPWP_REDIS_USERNAME' ), getenv( 'SPINUPWP_REDIS_PASSWORD' )];
         }
 
         foreach ( $settings as $setting ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: cache, caching, performance
 Requires at least: 4.7
 Tested up to: 6.8
 Requires PHP: 7.1
-Stable tag: 1.8.0
+Stable tag: 1.9.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,10 @@ Create a new team account, invite a member of your team, and allow them to spin 
 * Ensures debug.log files aren’t saved in a publicly-accessible location
 
 == Changelog ==
+
+= 1.9.0 (2025-07-25) =
+* Rename SPINUPWP_CACHE_* variables to SPINUPWP_REDIS_* to clarify Redis usage
+* Do not set WP_REDIS_SELECTIVE_FLUSH to true by default
 
 = 1.8.0 (2025-05-13) =
 * New: Support for Redis ACL and separate Redis databases


### PR DESCRIPTION
This PR changes the [previously added](https://github.com/spinupwp/spinupwp-plugin/pull/100) variables to use the `REDIS` keyword, which is more appropriate.

This also prevents the `WP_REDIS_SELECTIVE_FLUSH` constant from being set to `true` by default. As a result, when flushing the cache for a single site, the entire Redis database will be flushed. This change is intended to prevent timeout issues caused by slow Lua scripts when the cache grows large.

In the future, with the upcoming Redis ACL feature, each site will have its own Redis database. At that point, it will again be possible to flush the cache for a single site using Redis’ native `FLUSHDB`.