### PR TITLE
Add support for the new Redis object caching system

### DIFF
--- a/drop-ins/object-cache.php
+++ b/drop-ins/object-cache.php
@@ -3,7 +3,7 @@
 Plugin Name: SpinupWP Redis Object Cache Drop-In
 Plugin URI: http://wordpress.org/plugins/spinupwp/
 Description: A persistent object cache backend powered by Redis. Supports Predis, PhpRedis, HHVM, replication, clustering and WP-CLI.
-Version: 1.8.0
+Version: 1.9.0
 Author: SpinupWP
 Author URI: https://spinupwp.com/
 License: GPLv3
@@ -234,10 +234,6 @@ function wp_cache_init() {
 
     if ( ! defined( 'WP_REDIS_PREFIX' ) ) {
         define( 'WP_REDIS_PREFIX', get_cache_key_salt());
-    }
-
-    if ( ! defined( 'WP_REDIS_SELECTIVE_FLUSH' ) ) {
-        define( 'WP_REDIS_SELECTIVE_FLUSH', true );
     }
 
     if ( ! ( $wp_object_cache instanceof WP_Object_Cache ) ) {
@@ -633,7 +629,7 @@ class WP_Object_Cache {
             'scheme' => 'tcp',
             'host' => '127.0.0.1',
             'port' => 6379,
-            'database' => getenv('SPINUPWP_CACHE_DB') ?? 0,
+            'database' => (int) getenv('SPINUPWP_REDIS_DB') ?? 0,
             'timeout' => 5,
             'read_timeout' => 5,
             'retry_interval' => null,
@@ -652,9 +648,8 @@ class WP_Object_Cache {
             'retry_interval',
         ];
 
-
-        if ( getenv( 'SPINUPWP_CACHE_USERNAME' ) && getenv( 'SPINUPWP_CACHE_PASSWORD' ) ) {
-            $parameters['password'] = [getenv( 'SPINUPWP_CACHE_USERNAME' ), getenv( 'SPINUPWP_CACHE_PASSWORD' )];
+        if ( getenv( 'SPINUPWP_REDIS_USERNAME' ) && getenv( 'SPINUPWP_REDIS_PASSWORD' ) ) {
+            $parameters['password'] = [getenv( 'SPINUPWP_REDIS_USERNAME' ), getenv( 'SPINUPWP_REDIS_PASSWORD' )];
         }
 
         foreach ( $settings as $setting ) {
@@ -740,9 +735,7 @@ class WP_Object_Cache {
             call_user_func_array( [ $this->redis, 'connect' ], array_values( $args ) );
 
             if ( isset( $parameters['password'] ) ) {
-
                 $args['password'] = $parameters['password'];
-
                 $this->redis->auth( $parameters['password'] );
             }
 

--- a/readme.txt
+++ b/readme.txt
@@ -87,7 +87,7 @@ Create a new team account, invite a member of your team, and allow them to spin 
 == Changelog ==
 = 1.9.0 (2025-08-22) =
 * Change: Use SPINUPWP_REDIS_* variables instead of SPINUPWP_CACHE_*
-* Bug Fix: Prevent WP_REDIS_SELECTIVE_FLUSH from being set to true to ensure entire cache flush
+* Change: No longer enabling WP_REDIS_SELECTIVE_FLUSH by default as it can result in timeouts when flushing the cache.
 
 = 1.8.0 (2025-05-13) =
 * New: Support for Redis ACL and separate Redis databases

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: cache, caching, performance
 Requires at least: 4.7
 Tested up to: 6.8
 Requires PHP: 7.1
-Stable tag: 1.8.0
+Stable tag: 1.9.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,9 @@ Create a new team account, invite a member of your team, and allow them to spin 
 * Ensures debug.log files aren’t saved in a publicly-accessible location
 
 == Changelog ==
+= 1.9.0 (2025-08-22) =
+* Change: Use SPINUPWP_REDIS_* variables instead of SPINUPWP_CACHE_*
+* Bug Fix: Prevent WP_REDIS_SELECTIVE_FLUSH from being set to true to ensure entire cache flush
 
 = 1.8.0 (2025-05-13) =
 * New: Support for Redis ACL and separate Redis databases

--- a/spinupwp.php
+++ b/spinupwp.php
@@ -4,7 +4,7 @@ Plugin Name:  SpinupWP
 Plugin URI:   https://spinupwp.com
 Description:  SpinupWP helper plugin.
 Author:       SpinupWP
-Version:      1.8.0
+Version:      1.9.0
 Network:      True
 Text Domain:  spinupwp
 Requires PHP: 7.1


### PR DESCRIPTION
This PR updates all references of SPINUPWP_CACHE to SPINUPWP_REDIS in preparation for our upcoming Redis object cache system. We also discussed not setting `WP_REDIS_SELECTIVE_FLUSH` to true by default as the selective flush (Lua) can be quite slow.